### PR TITLE
Fix reference to syncagent CRDs

### DIFF
--- a/20250401-kubecon-london/workshop/03-dynamic-providers/01-deploy-postgres.sh
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/01-deploy-postgres.sh
@@ -13,7 +13,7 @@ export KUBECONFIG="${KUBECONFIGS_DIR}/provider.kubeconfig"
 kind_cluster_name='provider'
 
 ::kubectl::apply_from_file 'https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/releases/cnpg-1.25.1.yaml'
-::kubectl::apply_from_file 'https://raw.githubusercontent.com/kcp-dev/api-syncagent/refs/heads/main/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml'
+::kubectl::apply_from_file 'https://raw.githubusercontent.com/kcp-dev/api-syncagent/refs/tags/v0.2.0/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml'
 ::kubectl::apply_from_file "${EXERCISE_DIR}/apis/resources-cluster.yaml"
 ::kubectl::apply_from_file "${EXERCISE_DIR}/apis/resources-database.yaml"
 

--- a/20250401-kubecon-london/workshop/03-dynamic-providers/README.md
+++ b/20250401-kubecon-london/workshop/03-dynamic-providers/README.md
@@ -161,7 +161,7 @@ To do all of that, kcp offers one implementation of such a controller, the [api-
         ```
 
 ```shell
-kubectl apply --server-side -f https://raw.githubusercontent.com/kcp-dev/api-syncagent/refs/heads/main/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/kcp-dev/api-syncagent/refs/tags/v0.2.0/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml
 kubectl apply -f $EXERCISE_DIR/apis/resources-cluster.yaml
 kubectl apply -f $EXERCISE_DIR/apis/resources-database.yaml
 ```


### PR DESCRIPTION
Since the workshop the CRDs changed, yielding this error:
```
Error from server (BadRequest): error when creating "[...]/20250401-kubecon-london/workshop/03-dynamic-providers/apis/resources-cluster.yaml": PublishedResource in version "v1alpha1" cannot be handled as a PublishedResource: strict decoding error: unknown field "spec.related[0].reference"
```

This pins the tagged working version