### PR TITLE
Move last session to "Past learning materials"

### DIFF
--- a/website/content/learning/index.md
+++ b/website/content/learning/index.md
@@ -2,12 +2,7 @@
 
 Collection of learning material from kcp demo sessions.
 
-!!! tip "Session breakout for KubeCon 2025 London"
-
-    * Workshop: [**Exploring Multi-Tenant Kubernetes APIs and Controllers With kcp**](https://docs.kcp.io/contrib/learning/20250401-kubecon-london/workshop/)
-    * Talk: [**Extending Kubernetes Resource Model (KRM) Beyond Kubernetes Workloads**](https://sched.co/1txAB)
-    * Talk: [**Dynamic Multi-Cluster Controllers With Controller-runtime**](https://sched.co/1txFM)
-
 Past learning materials:
 
-* KubeCon 2024 Paris: [**KCP ML Shop demo**](http://localhost:8000/contrib/learning/20240321-kubecon-paris/) from session [**Why Kubernetes Is Inappropriate for Platforms, and How to Make It Better.**](https://sched.co/1YePC)
+* KubeCon 2024 Paris: [**KCP ML Shop demo**](https://docs.kcp.io/contrib/learning/20240321-kubecon-paris/) from session [**Why Kubernetes Is Inappropriate for Platforms, and How to Make It Better.**](https://sched.co/1YePC)
+* KubeCon 2025 London: [**Basics with kcp, and making your own DBaaS**](https://docs.kcp.io/contrib/learning/20250401-kubecon-london/workshop/) from session [**Tutorial: Exploring Multi-Tenant Kubernetes APIs and Controllers With kcp**](https://sched.co/1tx6b)


### PR DESCRIPTION
This PR updates the Learning landing page after kcon2025.